### PR TITLE
fix ReferenceError openPopup is not defined

### DIFF
--- a/src/view/frontend/templates/component/parcelshop.phtml
+++ b/src/view/frontend/templates/component/parcelshop.phtml
@@ -33,7 +33,7 @@ $url = $magewire->getMapUrl();
     <div id="parceslhop_desc" hidden="hidden"></div>
 
     <script>
-        function openPopup() {
+        window.openPopup = function() {
             var childWindow = open(
                 '<?= $escaper->escapeUrl($url) ?>',
                 "Mapa Parcelshop",


### PR DESCRIPTION
Fixes `ReferenceError openPopup is not defined` when opening the DHL Parcelshop popup in `/checkout`.